### PR TITLE
#4 link to docs re suppressing warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ And if you prefer a prettier report, here is a screen shot of the type of HTML r
 
 ![screenshot](https://raw.githubusercontent.com/sksamuel/scapegoat/master/screenshot1.png)
 
+### Configuration
+
+For instructions on suppressing warnings by file, by inspection or by line see [the sbt-scapegoat README](https://github.com/sksamuel/sbt-scapegoat).
+
 ### False positives
 
 Please note that scapegoat is a new project. While it's been tested on some common open source projects, there is still a good chance you'll find false positives. Please open up issues if you run into these so we can fix them.


### PR DESCRIPTION
Look OK?

Or would you rather duplicate the instructions in both READMEs?

Some of the linked instructions are SBT-specific, which might not be that helpful if people are trying to use `scapegoat` without SBT.

(There aren't any instructions at the linked README about per-line suppression yet, AFAICS. I'll raise a PR.)