### PR TITLE
Report compiler feedback to the reporter.

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -1,10 +1,11 @@
 package com.sksamuel.scapegoat
 
 import scala.collection.mutable.ListBuffer
-import scala.reflect.api.Position
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.Reporter
 
 /** @author Stephen Samuel */
-class Feedback(consoleOutput: Boolean) {
+class Feedback(consoleOutput: Boolean, reporter: Reporter) {
 
   val warnings = new ListBuffer[Warning]
 
@@ -33,6 +34,11 @@ class Feedback(consoleOutput: Boolean) {
       println(s"[${warning.level.toString.toLowerCase}] $sourceFile:${warning.line}: $text")
       snippet.foreach(s => println(s"          $s"))
       println()
+    }
+    level match {
+      case Levels.Error   => reporter.error(pos, text)
+      case Levels.Warning => reporter.warning(pos, text)
+      case Levels.Info    => reporter.info(pos, text, force = false)
     }
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat
 
-import scala.reflect.api.Position
+import scala.reflect.internal.util.Position
 import scala.tools.nsc.Global
 
 /** @author Stephen Samuel */

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -111,7 +111,7 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   def disableAll = disabled.exists(_.compareToIgnoreCase("all") == 0)
 
   def activeInspections = (inspections ++ customInpections).filterNot(inspection => disabled.contains(inspection.getClass.getSimpleName))
-  lazy val feedback = new Feedback(consoleOutput)
+  lazy val feedback = new Feedback(consoleOutput, global.reporter)
 
   override def newPhase(prev: scala.tools.nsc.Phase): Phase = new Phase(prev) {
     override def run(): Unit = {

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -1,0 +1,41 @@
+package com.sksamuel.scapegoat
+
+import com.sksamuel.scapegoat.inspections.AnyUse
+import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
+
+import scala.reflect.internal.util.NoPosition
+import scala.tools.nsc.reporters.StoreReporter
+
+/** @author Stephen Samuel */
+class FeedbackTest
+    extends FreeSpec
+    with Matchers
+    with OneInstancePerTest {
+
+  val message = "Some problem"
+  val position = NoPosition
+  val inspection = new AnyUse
+
+  "Feedback" - {
+    "should report to reporter" - {
+      "for error" in {
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter)
+        feedback.warn(message, position, Levels.Error, inspection)
+        reporter.infos should contain(reporter.Info(position, message, reporter.ERROR))
+      }
+      "for warning" in {
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter)
+        feedback.warn(message, position, Levels.Warning, inspection)
+        reporter.infos should contain(reporter.Info(position, message, reporter.WARNING))
+      }
+      "for info" in {
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter)
+        feedback.warn(message, position, Levels.Info, inspection)
+        reporter.infos should contain(reporter.Info(position, message, reporter.INFO))
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -53,10 +53,6 @@ trait PluginRunner {
     reporter.flush()
     val command = new scala.tools.nsc.CompilerCommand(files.map(_.getAbsolutePath).toList, settings)
     new compiler.Run().compile(command.files)
-    if (reporter.hasErrors)
-      throw new RuntimeException
-    if (reporter.hasWarnings)
-      throw new RuntimeException
     compiler
   }
 


### PR DESCRIPTION
This will let us report warnings/errors to sbt for it to handle appropriately.

This should fix sksamuel/sbt-scapegoat#25

With this change, the Feedback console output is somewhat duplicated. One thing the console output has that the sbt output doesn't is the optional snippet. That should be easy enough to send to the reporter so that the Feedback console output can go away completely.