### PR TITLE
Fix ArrayEquals false-positive when comparing an array to null

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
@@ -10,11 +10,23 @@ class ArrayEquals extends Inspection {
 
       import context.global._
 
-      private def isArray(tree: Tree) = tree.tpe <:< typeOf[Array[_]]
+      private def isArray(tree: Tree) = tree match {
+        // "null" is deprecated, but comparing an array to null can be useful
+        // in some cases (e.g. when interfacing with null-using Java code) and
+        // shouldn't trigger this warning, which relates to whether the
+        // equality is reference-equality or value-equality.
+        //
+        // We have to add a special case here, because the 'type' of null will
+        // be coerced to Array when it is compared to an array, so it would
+        // otherwise match the next case.
+        case Literal(Constant(null)) => false
+        case x                       => x.tpe <:< typeOf[Array[_]]
+      }
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(lhs, TermName("$eq$eq")), List(rhs)) if isArray(lhs) && isArray(rhs) =>
+          case Apply(Select(lhs, TermName("$eq$eq") | TermName("$bang$eq")), List(rhs)) if isArray(lhs) && isArray(rhs) =>
+
             context.warn("Array equals",
               tree.pos,
               Levels.Info,

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEqualsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEqualsTest.scala
@@ -21,6 +21,18 @@ class ArrayEqualsTest extends FreeSpec with Matchers with PluginRunner with OneI
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
+      "for comparing two arrays using !=" in {
+
+        val code = """class Test {
+                     val a = Array(1,2,3)
+                     val b = Array(1,2,3)
+                     println(a != b)
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
     }
     "should not report warning" - {
       "for comparing two arrays using deep" in {
@@ -29,6 +41,17 @@ class ArrayEqualsTest extends FreeSpec with Matchers with PluginRunner with OneI
                      val a = Array(1,2,3)
                      val b = Array(1,2,3)
                      println(a.deep == b.deep)
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+      "for comparing an array to null" in {
+
+        val code = """class Test {
+                     val a = Array(1,2,3)
+                     println(a != null)
+                     println(a == null)
                     } """.stripMargin
 
         compileCodeSnippet(code)


### PR DESCRIPTION
Fix ArrayEquals false-positive when comparing an array to null, and include NE in the warning