### PR TITLE
Fix java.util.NoSuchElementException: head of empty list

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -20,7 +20,10 @@ class CollectionPromotionToAny extends Inspection {
       }
 
       private def isAny(tree: Tree): Boolean = tree.toString() == "Any"
-      private def isAny(symbol: Symbol): Boolean = symbol.typeSignature.resultType.typeArgs.head.toString == "Any"
+      private def isAny(symbol: Symbol): Boolean = symbol.typeSignature.resultType.typeArgs.headOption match {
+        case Some(t) => t.toString == "Any"
+        case None => false
+      }
 
       private def isAnySeq(tree: Tree): Boolean = tree match {
         case select @ Select(_, _) if select.symbol != null => isSeq(select.symbol) && isAny(select.symbol)


### PR DESCRIPTION
The following causes the compiler to fail:

```scala
object Test extends App {
  type SList = List[String]
  val a: SList = List()
  val b = a :+ "c"
}
```

Stacktrace
```
java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:420)
	at scala.collection.immutable.Nil$.head(List.scala:417)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.isAny(CollectionPromotionToAny.scala:23)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.isAnySeq(CollectionPromotionToAny.scala:26)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:33)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.internal.Trees$class.traverseComponents$1(Trees.scala:1283)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1330)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.internal.Trees$class.traverseComponents$1(Trees.scala:1283)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1330)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.internal.Trees$$anonfun$traverseMemberDef$1$1.apply$mcV$sp(Trees.scala:1209)
	at scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
	at scala.reflect.internal.Trees$class.traverseMemberDef$1(Trees.scala:1203)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1328)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.api.Trees$Traverser$$anonfun$traverseStats$1$$anonfun$apply$1.apply$mcV$sp(Trees.scala:2498)
	at scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
	at scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2497)
	at scala.reflect.internal.Trees$class.traverseComponents$1(Trees.scala:1232)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1330)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.internal.Trees$$anonfun$traverseMemberDef$1$1.apply$mcV$sp(Trees.scala:1208)
	at scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
	at scala.reflect.internal.Trees$class.traverseMemberDef$1(Trees.scala:1203)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1327)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at scala.reflect.api.Trees$Traverser$$anonfun$traverseStats$1$$anonfun$apply$1.apply$mcV$sp(Trees.scala:2498)
	at scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
	at scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2497)
	at scala.reflect.internal.Trees$class.itraverse(Trees.scala:1326)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.com$sksamuel$scapegoat$InspectionContext$Traverser$$super$traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.continue(Inspection.scala:71)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.continue(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.inspect(CollectionPromotionToAny.scala:36)
	at com.sksamuel.scapegoat.InspectionContext$Traverser$class.traverse(Inspection.scala:86)
	at com.sksamuel.scapegoat.inspections.collections.CollectionPromotionToAny$$anon$2$$anon$1.traverse(CollectionPromotionToAny.scala:12)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer$$anonfun$transform$2$$anonfun$apply$1.apply(plugin.scala:173)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer$$anonfun$transform$2$$anonfun$apply$1.apply(plugin.scala:172)
	at scala.Option.foreach(Option.scala:257)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer$$anonfun$transform$2.apply(plugin.scala:172)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer$$anonfun$transform$2.apply(plugin.scala:170)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer.transform(plugin.scala:170)
	at com.sksamuel.scapegoat.ScapegoatComponent$Transformer.transform(plugin.scala:159)
	at scala.tools.nsc.ast.Trees$Transformer.transformUnit(Trees.scala:147)
	at scala.tools.nsc.transform.Transform$Phase.apply(Transform.scala:30)
	at scala.tools.nsc.Global$GlobalPhase$$anonfun$applyPhase$1.apply$mcV$sp(Global.scala:440)
	at scala.tools.nsc.Global$GlobalPhase.withCurrentUnit(Global.scala:431)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:440)
	at scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:398)
	at scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:398)
	at scala.collection.Iterator$class.foreach(Iterator.scala:742)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1194)
	at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:398)
	at com.sksamuel.scapegoat.ScapegoatComponent$$anon$1.run(plugin.scala:128)
	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1501)
	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1486)
	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1481)
	at scala.tools.nsc.Global$Run.compile(Global.scala:1582)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:116)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:95)
	at xsbt.CompilerInterface.run(CompilerInterface.scala:26)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:101)
	at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:47)
	at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:41)
	at sbt.compiler.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply$mcV$sp(MixedAnalyzingCompiler.scala:51)
	at sbt.compiler.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:51)
	at sbt.compiler.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:51)
	at sbt.compiler.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:75)
	at sbt.compiler.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:50)
	at sbt.compiler.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:65)
	at sbt.compiler.IC$$anonfun$compileInternal$1.apply(IncrementalCompiler.scala:160)
	at sbt.compiler.IC$$anonfun$compileInternal$1.apply(IncrementalCompiler.scala:160)
	at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:66)
	at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:64)
	at sbt.inc.IncrementalCommon.cycle(IncrementalCommon.scala:31)
	at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:62)
	at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:61)
	at sbt.inc.Incremental$.manageClassfiles(Incremental.scala:89)
	at sbt.inc.Incremental$.compile(Incremental.scala:61)
	at sbt.inc.IncrementalCompile$.apply(Compile.scala:54)
	at sbt.compiler.IC$.compileInternal(IncrementalCompiler.scala:160)
	at sbt.compiler.IC$.incrementalCompile(IncrementalCompiler.scala:138)
	at sbt.Compiler$.compile(Compiler.scala:128)
	at sbt.Compiler$.compile(Compiler.scala:114)
	at sbt.Defaults$.sbt$Defaults$$compileIncrementalTaskImpl(Defaults.scala:814)
	at sbt.Defaults$$anonfun$compileIncrementalTask$1.apply(Defaults.scala:805)
	at sbt.Defaults$$anonfun$compileIncrementalTask$1.apply(Defaults.scala:803)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:235)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[error] (scapegoat:compileIncremental) java.util.NoSuchElementException: head of empty list
```

