### PR TITLE
ComparingUnrelatedTypes: special case value classes

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
@@ -15,9 +15,12 @@ class ComparingUnrelatedTypes extends Inspection {
           case Apply(Select(lhs, TermName("$eq$eq")), List(Literal(Constant(0)))) if lhs.tpe.typeSymbol.isNumericValueClass =>
           case Apply(Select(Literal(Constant(0)), TermName("$eq$eq")), List(rhs)) if rhs.tpe.typeSymbol.isNumericValueClass =>
           case Apply(Select(lhs, TermName("$eq$eq")), List(rhs)) =>
-            val q = lhs
-            val l = lhs.tpe.erasure
-            val r = rhs.tpe.erasure
+            val (l, r) = if (lhs.tpe.typeSymbol.asClass.isDerivedValueClass || rhs.tpe.typeSymbol.asClass.isDerivedValueClass) {
+              (lhs.tpe, rhs.tpe)
+            } else {
+              (lhs.tpe.erasure, rhs.tpe.erasure)
+            }
+
             if (!(l <:< r || r <:< l || l =:= r)) {
               context.warn("Comparing unrelated types", tree.pos, Levels.Error, tree.toString().take(500), ComparingUnrelatedTypes.this)
             }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
@@ -11,19 +11,25 @@ class ComparingUnrelatedTypesTest extends FreeSpec with Matchers with PluginRunn
 
   "ComparingUnrelatedTypes" - {
     "should report warning" in {
-      val code = """class Test {
-                      val a = new RuntimeException
-                      val b = new Exception
+      val code = """
+        case class SomeValueClass(i: Int) extends AnyVal
+        class Test {
+          val a = new RuntimeException
+          val b = new Exception
 
-                      "sammy" == BigDecimal(10) // warning 1
-                      "sammy" == "bobby" // same type
-                      a == b // superclass
-                      a == "sammy" // warning 2
-                      Some("sam") == Option("laura") // ok
-                      Nil == Set.empty // warning 3
-                    } """.stripMargin
+          "sammy" == BigDecimal(10) // warning 1
+          "sammy" == "bobby" // same type
+          a == b // superclass
+          a == "sammy" // warning 2
+          Some("sam") == Option("laura") // ok
+          Nil == Set.empty // warning 3
+          Some(1) match {
+            case Some(x) if x == SomeValueClass(1) => () // warning 4
+            case _ => ()
+          }
+        } """.stripMargin
       compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 3
+      compiler.scapegoat.feedback.warnings.size shouldBe 4
     }
     "should not report warning" - {
       "for long compared to zero" in {


### PR DESCRIPTION
The existing check uses type erasure with value classes, which causes this check to pass when it shouldn't.